### PR TITLE
Erlaube lokale Scripte

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1,5 +1,10 @@
 set fogServerIP=192.168.4.2
 
 powershell -Command Set-ExecutionPolicy -ExecutionPolicy Unrestricted
+if exist .\install.ps1 goto local
 curl.exe -o %TEMP%\install.ps1 http://%fogServerIP%/fwe-fog/install.ps1
 powershell -File %TEMP%\install.ps1
+goto done
+:local
+powershell -File .\install.ps1
+:done

--- a/install.ps1
+++ b/install.ps1
@@ -50,10 +50,15 @@ function Elevate-Privileges {
 }
 
 Function Run($script) {
-    Write-Output "Downloading $script"
-    curl.exe -o $env:TEMP\$script http://$fogServerIP/fwe-fog/scripts/$script
-    Write-Output "Running $script"
-    . $env:TEMP\$script
+    if (Test-Path .\scripts\$script) {
+        Write-Output "Running local $script"
+        . .\scripts\$script
+    } else {
+        Write-Output "Downloading $script"
+        curl.exe -o $env:TEMP\$script http://$fogServerIP/fwe-fog/scripts/$script
+        Write-Output "Running $script"
+        . $env:TEMP\$script
+    }
 }
 
 Run("disable-fastboot.ps1")

--- a/scripts/install-unattend.ps1
+++ b/scripts/install-unattend.ps1
@@ -3,6 +3,11 @@ $ErrorActionPreference = 'Stop'
 $fogServerIP = "192.168.4.2"
 
 $unattendXML = "unattend.xml"
-Write-Output "Downloading $unattendXML"
-curl.exe -o $env:TEMP\$unattendXML http://$fogServerIP/fwe-fog/conf/$unattendXML
-Move-Item -Force $env:TEMP\$unattendXML C:\Windows\Panther\unattend.xml
+if (Test-Path .\conf\$unattendXML) {
+    Write-Output "Use local $unattendXML"
+    Copy-Item -Force .\conf\$unattendXML C:\Windows\Panther\unattend.xml
+} else {
+    Write-Output "Downloading $unattendXML"
+    curl.exe -o $env:TEMP\$unattendXML http://$fogServerIP/fwe-fog/conf/$unattendXML
+    Move-Item -Force $env:TEMP\$unattendXML C:\Windows\Panther\unattend.xml
+}


### PR DESCRIPTION
Wenn man alle Dateien gleich auf einen USB-Stick kopiert, dann kann man ganz ohne den FOG-Server den Rechner vorinstallieren.